### PR TITLE
PR replaces client-side PCA with server-side UMAP clustering

### DIFF
--- a/website/scripts/02-generate_projections.py
+++ b/website/scripts/02-generate_projections.py
@@ -1,0 +1,56 @@
+
+import json
+import numpy as np
+import umap
+from sklearn.preprocessing import MinMaxScaler
+
+# Read data from the saturation JSON file 
+with open("website/web/data/saturation.json", "r") as f:
+    data_saturation = json.load(f)
+
+# Vectorise data
+tasks = list(data_saturation.keys())
+task_to_vector = {task: [1 if i == j else 0 for i in range(len(tasks))] for j, task in enumerate(tasks)}
+
+vectorized_data = []
+for task, datasets in data_saturation.items():
+    for dataset_name, data in datasets.items():
+        vectorized_data.append({
+            "name": dataset_name,
+            "task": task,
+            "saturation": data["saturation"],
+            "vector": [
+                *task_to_vector[task],
+                data["saturation"],
+                data["year"],
+                1 if data["public"] else 0,
+                data["size"]
+            ]
+        })
+
+vectors = np.array([d["vector"] for d in vectorized_data])
+
+# Scale the data before UMAP
+scaler = MinMaxScaler()
+scaled_vectors = scaler.fit_transform(vectors)
+
+# Apply UMAP
+reducer = umap.UMAP(n_neighbors=15, min_dist=0.1, n_components=2, random_state=42)
+embedding = reducer.fit_transform(scaled_vectors)
+
+# Create the output data structure
+output_data = []
+for i, d in enumerate(vectorized_data):
+    output_data.append({
+        "name": d["name"],
+        "task": d["task"],
+        "saturation": d["saturation"],
+        "x": float(embedding[i, 0]),
+        "y": float(embedding[i, 1])
+    })
+
+# Save to A JSON file for the website to use
+with open("website/web/data/projections.json", "w") as f:
+    json.dump(output_data, f, indent=2)
+
+print("UMAP projections generated and saved to website/web/data/projections.json") 

--- a/website/src/package-lock.json
+++ b/website/src/package-lock.json
@@ -8,8 +8,7 @@
                 "billboard.js": "^3.16.0",
                 "datatables.net": "^2.1.8",
                 "datatables.net-dt": "^2.1.8",
-                "jquery": "^3.7.1",
-                "ml-pca": "^4.1.1"
+                "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@types/datatables.net": "^1.10.28",
@@ -2401,12 +2400,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/is-any-array": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
-            "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
-            "license": "MIT"
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2794,54 +2787,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/ml-array-max": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
-            "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "is-any-array": "^2.0.0"
-            }
-        },
-        "node_modules/ml-array-min": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
-            "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
-            "license": "MIT",
-            "dependencies": {
-                "is-any-array": "^2.0.0"
-            }
-        },
-        "node_modules/ml-array-rescale": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
-            "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
-            "license": "MIT",
-            "dependencies": {
-                "is-any-array": "^2.0.0",
-                "ml-array-max": "^1.2.4",
-                "ml-array-min": "^1.2.3"
-            }
-        },
-        "node_modules/ml-matrix": {
-            "version": "6.12.1",
-            "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.1.tgz",
-            "integrity": "sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-any-array": "^2.0.1",
-                "ml-array-rescale": "^1.3.7"
-            }
-        },
-        "node_modules/ml-pca": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ml-pca/-/ml-pca-4.1.1.tgz",
-            "integrity": "sha512-HQwswMK1dObj+ppk3EPcQMR2djWK0Cri8mAFd2nITtXHkLfO4DBBsEtiCT5KiR+2e3hQjp+lI0UyqZpdf04AlQ==",
-            "license": "MIT",
-            "dependencies": {
-                "ml-matrix": "^6.8.0"
             }
         },
         "node_modules/ms": {

--- a/website/src/package.json
+++ b/website/src/package.json
@@ -27,7 +27,6 @@
         "billboard.js": "^3.16.0",
         "datatables.net": "^2.1.8",
         "datatables.net-dt": "^2.1.8",
-        "jquery": "^3.7.1",
-        "ml-pca": "^4.1.1"
+        "jquery": "^3.7.1"
     }
 }

--- a/website/web/data/projections.json
+++ b/website/web/data/projections.json
@@ -1,0 +1,492 @@
+[
+  {
+    "name": "WMT20",
+    "task": "Translation",
+    "saturation": 0.9,
+    "x": 3.5329763889312744,
+    "y": 11.85244083404541
+  },
+  {
+    "name": "WMT21",
+    "task": "Translation",
+    "saturation": 0.85,
+    "x": 3.6122772693634033,
+    "y": 12.175298690795898
+  },
+  {
+    "name": "WMT22",
+    "task": "Translation",
+    "saturation": 0.8,
+    "x": 3.5119869709014893,
+    "y": 11.805851936340332
+  },
+  {
+    "name": "WMT23",
+    "task": "Translation",
+    "saturation": 0.8,
+    "x": 3.5613391399383545,
+    "y": 12.107125282287598
+  },
+  {
+    "name": "WMT24",
+    "task": "Translation",
+    "saturation": 0.77,
+    "x": 3.8305015563964844,
+    "y": 12.14299488067627
+  },
+  {
+    "name": "SummEval",
+    "task": "Summarization",
+    "saturation": 1.0,
+    "x": 6.601155757904053,
+    "y": 9.606281280517578
+  },
+  {
+    "name": "MyEval",
+    "task": "Summarization",
+    "saturation": 0.7,
+    "x": 6.99563455581665,
+    "y": 9.76455307006836
+  },
+  {
+    "name": "BookSum",
+    "task": "Summarization",
+    "saturation": 1.0,
+    "x": 6.645829677581787,
+    "y": 9.500019073486328
+  },
+  {
+    "name": "ScisummNet",
+    "task": "Summarization",
+    "saturation": 0.95,
+    "x": 6.796776294708252,
+    "y": 9.426114082336426
+  },
+  {
+    "name": "LongSum",
+    "task": "Summarization",
+    "saturation": 0.3,
+    "x": 7.06406831741333,
+    "y": 9.981793403625488
+  },
+  {
+    "name": "HellaSwag",
+    "task": "Open-Ended",
+    "saturation": 0.6,
+    "x": 8.011480331420898,
+    "y": 12.63090991973877
+  },
+  {
+    "name": "OpenBookQA",
+    "task": "Open-Ended",
+    "saturation": 0.45,
+    "x": 8.090879440307617,
+    "y": 12.630791664123535
+  },
+  {
+    "name": "ARC",
+    "task": "Open-Ended",
+    "saturation": 0.6,
+    "x": 8.114336013793945,
+    "y": 12.567676544189453
+  },
+  {
+    "name": "MMLU",
+    "task": "Open-Ended",
+    "saturation": 0.85,
+    "x": 7.9288249015808105,
+    "y": 12.555508613586426
+  },
+  {
+    "name": "Winogrande",
+    "task": "Open-Ended",
+    "saturation": 0.9,
+    "x": 7.841241359710693,
+    "y": 12.818045616149902
+  },
+  {
+    "name": "TriviaQA",
+    "task": "Closed-Ended",
+    "saturation": 1.0,
+    "x": 5.7520880699157715,
+    "y": 8.538041114807129
+  },
+  {
+    "name": "NaturalQuest",
+    "task": "Closed-Ended",
+    "saturation": 0.99,
+    "x": 5.9242048263549805,
+    "y": 8.70059871673584
+  },
+  {
+    "name": "HotpotQA",
+    "task": "Closed-Ended",
+    "saturation": 1.0,
+    "x": 5.769077301025391,
+    "y": 8.922722816467285
+  },
+  {
+    "name": "WebQuestions",
+    "task": "Closed-Ended",
+    "saturation": 0.99,
+    "x": 6.046011447906494,
+    "y": 8.797266960144043
+  },
+  {
+    "name": "SearchQA",
+    "task": "Closed-Ended",
+    "saturation": 0.99,
+    "x": 5.801962852478027,
+    "y": 8.598353385925293
+  },
+  {
+    "name": "ARC",
+    "task": "Reasoning",
+    "saturation": 0.6,
+    "x": 8.059211730957031,
+    "y": 11.898818969726562
+  },
+  {
+    "name": "HellaSwag",
+    "task": "Reasoning",
+    "saturation": 0.6,
+    "x": 7.950589656829834,
+    "y": 11.614466667175293
+  },
+  {
+    "name": "OpenBookQA",
+    "task": "Reasoning",
+    "saturation": 0.45,
+    "x": 8.165836334228516,
+    "y": 11.712608337402344
+  },
+  {
+    "name": "MMLU",
+    "task": "Reasoning",
+    "saturation": 0.85,
+    "x": 8.247671127319336,
+    "y": 11.80896282196045
+  },
+  {
+    "name": "Winogrande",
+    "task": "Reasoning",
+    "saturation": 0.9,
+    "x": 8.000589370727539,
+    "y": 11.512208938598633
+  },
+  {
+    "name": "MS MARCO",
+    "task": "Retrieval",
+    "saturation": 0.95,
+    "x": 4.193902969360352,
+    "y": 9.207406044006348
+  },
+  {
+    "name": "TREC",
+    "task": "Retrieval",
+    "saturation": 0.9,
+    "x": 4.265140533447266,
+    "y": 9.349629402160645
+  },
+  {
+    "name": "NQ",
+    "task": "Retrieval",
+    "saturation": 0.99,
+    "x": 3.9528489112854004,
+    "y": 9.39258098602295
+  },
+  {
+    "name": "HotpotQA",
+    "task": "Retrieval",
+    "saturation": 1.0,
+    "x": 4.233558177947998,
+    "y": 9.124120712280273
+  },
+  {
+    "name": "TriviaQA",
+    "task": "Retrieval",
+    "saturation": 1.0,
+    "x": 4.392767906188965,
+    "y": 9.166178703308105
+  },
+  {
+    "name": "AG News",
+    "task": "Classification",
+    "saturation": 0.95,
+    "x": 7.435995578765869,
+    "y": 8.360871315002441
+  },
+  {
+    "name": "SST-2",
+    "task": "Classification",
+    "saturation": 0.9,
+    "x": 7.348807334899902,
+    "y": 8.491427421569824
+  },
+  {
+    "name": "IMDB",
+    "task": "Classification",
+    "saturation": 0.85,
+    "x": 7.727361679077148,
+    "y": 8.067094802856445
+  },
+  {
+    "name": "Yelp",
+    "task": "Classification",
+    "saturation": 0.8,
+    "x": 7.6423258781433105,
+    "y": 8.176752090454102
+  },
+  {
+    "name": "TREC",
+    "task": "Classification",
+    "saturation": 0.9,
+    "x": 7.420914173126221,
+    "y": 8.408551216125488
+  },
+  {
+    "name": "WikiText-2",
+    "task": "Generation",
+    "saturation": 0.9,
+    "x": 8.642542839050293,
+    "y": 10.654541015625
+  },
+  {
+    "name": "LAMBADA",
+    "task": "Generation",
+    "saturation": 0.85,
+    "x": 8.963269233703613,
+    "y": 10.6337251663208
+  },
+  {
+    "name": "Text8",
+    "task": "Generation",
+    "saturation": 0.8,
+    "x": 8.84361743927002,
+    "y": 10.767936706542969
+  },
+  {
+    "name": "PTB",
+    "task": "Generation",
+    "saturation": 0.75,
+    "x": 8.5015230178833,
+    "y": 10.562018394470215
+  },
+  {
+    "name": "Penn Treebank",
+    "task": "Generation",
+    "saturation": 0.7,
+    "x": 8.537737846374512,
+    "y": 11.01521110534668
+  },
+  {
+    "name": "ImageNet",
+    "task": "Vision",
+    "saturation": 0.95,
+    "x": 9.685382843017578,
+    "y": 8.443300247192383
+  },
+  {
+    "name": "CIFAR-10",
+    "task": "Vision",
+    "saturation": 0.9,
+    "x": 9.778294563293457,
+    "y": 8.53072738647461
+  },
+  {
+    "name": "CIFAR-100",
+    "task": "Vision",
+    "saturation": 0.85,
+    "x": 9.681381225585938,
+    "y": 8.793391227722168
+  },
+  {
+    "name": "MNIST",
+    "task": "Vision",
+    "saturation": 0.8,
+    "x": 10.001202583312988,
+    "y": 8.509587287902832
+  },
+  {
+    "name": "FashionMNIST",
+    "task": "Vision",
+    "saturation": 0.75,
+    "x": 9.519375801086426,
+    "y": 8.740413665771484
+  },
+  {
+    "name": "LibriSpeech",
+    "task": "Audio",
+    "saturation": 0.95,
+    "x": 6.654099464416504,
+    "y": 13.120553970336914
+  },
+  {
+    "name": "CommonVoice",
+    "task": "Audio",
+    "saturation": 0.9,
+    "x": 6.510944843292236,
+    "y": 12.860893249511719
+  },
+  {
+    "name": "VoxCeleb",
+    "task": "Audio",
+    "saturation": 0.85,
+    "x": 6.409794807434082,
+    "y": 13.015776634216309
+  },
+  {
+    "name": "Urban8K",
+    "task": "Audio",
+    "saturation": 0.8,
+    "x": 6.2242751121521,
+    "y": 12.886969566345215
+  },
+  {
+    "name": "ESC-50",
+    "task": "Audio",
+    "saturation": 0.75,
+    "x": 6.539693355560303,
+    "y": 12.700703620910645
+  },
+  {
+    "name": "VQA",
+    "task": "Multimodal",
+    "saturation": 0.9,
+    "x": 6.79241418838501,
+    "y": 11.155158996582031
+  },
+  {
+    "name": "MS COCO",
+    "task": "Multimodal",
+    "saturation": 0.85,
+    "x": 6.510048866271973,
+    "y": 11.358931541442871
+  },
+  {
+    "name": "Flickr30k",
+    "task": "Multimodal",
+    "saturation": 0.8,
+    "x": 6.763461112976074,
+    "y": 11.43781852722168
+  },
+  {
+    "name": "Visual Genome",
+    "task": "Multimodal",
+    "saturation": 0.75,
+    "x": 6.713433742523193,
+    "y": 11.445952415466309
+  },
+  {
+    "name": "CLEVR",
+    "task": "Multimodal",
+    "saturation": 0.7,
+    "x": 7.022225856781006,
+    "y": 11.29328727722168
+  },
+  {
+    "name": "UCR Archive",
+    "task": "Time Series",
+    "saturation": 0.95,
+    "x": 10.024746894836426,
+    "y": 12.338214874267578
+  },
+  {
+    "name": "ECG5000",
+    "task": "Time Series",
+    "saturation": 0.9,
+    "x": 10.06119155883789,
+    "y": 12.279294967651367
+  },
+  {
+    "name": "ElectricDevices",
+    "task": "Time Series",
+    "saturation": 0.85,
+    "x": 10.051146507263184,
+    "y": 12.676993370056152
+  },
+  {
+    "name": "FaceDetection",
+    "task": "Time Series",
+    "saturation": 0.8,
+    "x": 9.823065757751465,
+    "y": 12.522797584533691
+  },
+  {
+    "name": "GesturePhase",
+    "task": "Time Series",
+    "saturation": 0.75,
+    "x": 9.677875518798828,
+    "y": 12.541743278503418
+  },
+  {
+    "name": "Cora",
+    "task": "Graph",
+    "saturation": 0.9,
+    "x": 10.610681533813477,
+    "y": 10.769493103027344
+  },
+  {
+    "name": "Citeseer",
+    "task": "Graph",
+    "saturation": 0.85,
+    "x": 10.457385063171387,
+    "y": 10.789485931396484
+  },
+  {
+    "name": "Pubmed",
+    "task": "Graph",
+    "saturation": 0.8,
+    "x": 10.614529609680176,
+    "y": 10.96617317199707
+  },
+  {
+    "name": "Reddit",
+    "task": "Graph",
+    "saturation": 0.75,
+    "x": 10.759283065795898,
+    "y": 10.625165939331055
+  },
+  {
+    "name": "Amazon",
+    "task": "Graph",
+    "saturation": 0.7,
+    "x": 10.40578842163086,
+    "y": 10.941514015197754
+  },
+  {
+    "name": "Adult",
+    "task": "Tabular",
+    "saturation": 0.95,
+    "x": 10.903059005737305,
+    "y": 9.633820533752441
+  },
+  {
+    "name": "IncomeCens",
+    "task": "Tabular",
+    "saturation": 0.9,
+    "x": 10.99842357635498,
+    "y": 9.48831844329834
+  },
+  {
+    "name": "Card Fraud",
+    "task": "Tabular",
+    "saturation": 0.85,
+    "x": 10.970475196838379,
+    "y": 9.678041458129883
+  },
+  {
+    "name": "Titanic",
+    "task": "Tabular",
+    "saturation": 0.8,
+    "x": 10.88916015625,
+    "y": 9.515847206115723
+  },
+  {
+    "name": "House Prices",
+    "task": "Tabular",
+    "saturation": 0.75,
+    "x": 11.237787246704102,
+    "y": 9.605974197387695
+  }
+]

--- a/website/web/index.html
+++ b/website/web/index.html
@@ -109,7 +109,7 @@
             Click on a dataset to see details.
         </div>
 
-        <h2 style="margin-top: 30px;">Dataset Clustering (PCA)</h2>
+        <h2 style="margin-top: 30px;">Dataset Clustering (UMAP)</h2>
         <div id="cluster_chart_container" style="margin-top: 20px; margin-left: auto; margin-right: auto; width: 800px;"></div>
 
             <div

--- a/website/web/style.css
+++ b/website/web/style.css
@@ -689,7 +689,7 @@ table.dataTable thead .sorting_desc:before {
     display: none; /* Hide tick lines */
 }
 
-.pca_tooltip {
+.umap_tooltip {
     background-color: #fff9;
     font-size: 10pt;
 }


### PR DESCRIPTION
- remove ml-pca dependency & browser-based computation
- added python script (02-generate_projections.py) that uses UMAP for dimensionality reduction
- updtaed frontend to load pre-computed projections from JSON
- Changed UI labels & styling from PCA to UMAP

UMAP chosen over t-SNE for better preservation of both local & global structure. [link](https://aicompetence.org/comparing-t-sne-and-umap/)

Resolves #12

new:
<img width="1511" height="732" alt="image" src="https://github.com/user-attachments/assets/cfa1a249-aa3f-4a16-9812-0f7751198152" />
